### PR TITLE
Updated project dependency conditionally for missing-doclet

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -24,7 +24,13 @@ pluginManagement {
 
 rootProject.name = "lucene-root"
 
-includeBuild("dev-tools/missing-doclet")
+def folder = new File( '../dev-tools/solr-missing-doclet' )
+
+if( folder.exists() ) {
+    includeBuild("../dev-tools/solr-missing-doclet")
+} else {
+    includeBuild("dev-tools/missing-doclet")
+}
 
 include "lucene:analysis:common"
 include "lucene:analysis:icu"


### PR DESCRIPTION
Solr9.0 and lucene has same project dependency on `dev-tools/missing-doclet`. Thus adding conditional  dependency on that project. if lucene compiles from solr then lucene points to solr's missing-doclet project.
