### PR TITLE
WIP experiment: allow extended lz4 lookback window

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/compress/LZ4.java
+++ b/lucene/core/src/java/org/apache/lucene/util/compress/LZ4.java
@@ -569,9 +569,10 @@ public final class LZ4 {
       throws IOException {
     Objects.checkFromIndexSize(dictOff, dictLen, bytes.length);
     Objects.checkFromIndexSize(dictOff + dictLen, len, bytes.length);
-    if (dictLen > MAX_DISTANCE) {
+    final int maxDistance = ext ? EXTENDED_MAX_DISTANCE : MAX_DISTANCE;
+    if (dictLen > maxDistance) {
       throw new IllegalArgumentException(
-          "dictLen must not be greater than 64kB, but got " + dictLen);
+          "dictLen must not be greater than " + (ext ? "256k" : "64k") + ", but got " + dictLen);
     }
 
     final int end = dictOff + dictLen + len;
@@ -607,7 +608,7 @@ public final class LZ4 {
         int matchLen = MIN_MATCH + commonBytes(bytes, ref + MIN_MATCH, off + MIN_MATCH, limit);
 
         // try to find a better match
-        for (int r = ht.previous(ref), min = Math.max(off - MAX_DISTANCE + 1, dictOff);
+        for (int r = ht.previous(ref), min = Math.max(off - maxDistance + 1, dictOff);
             r >= min;
             r = ht.previous(r)) {
           assert readInt(bytes, r) == readInt(bytes, off);

--- a/lucene/core/src/java/org/apache/lucene/util/compress/LZ4.java
+++ b/lucene/core/src/java/org/apache/lucene/util/compress/LZ4.java
@@ -72,7 +72,7 @@ public final class LZ4 {
    * provide {@link #DEFAULT_EXTENDED_MAX_DISTANCE} to allow tests to be run exercising lz4 with
    * {@link #EXTENDED_MAX_DISTANCE}.
    */
-  public static final boolean DEFAULT_EXTENDED_MAX_DISTANCE = true;
+  public static final boolean DEFAULT_EXTENDED_MAX_DISTANCE = false;
 
   static final int MEMORY_USAGE = 14;
   static final int MIN_MATCH = 4; // minimum length of a match


### PR DESCRIPTION
There are some use cases (e. g., 256k block-level compression applied over index files) where the period of pattern repetition is longer. Such cases benefit from a combination of LZ4.HighCompressionHashTable and a longer lookback window (256k instead of the default Lucene lz4 64k lookback window). The benefits are both in compression (real-world cases with ~3x improved compression!), but also in latency/ CPU-efficiency, in some cases with >2x faster execution.

This is quick/dirty patch to support this approach for demonstration/experimentation.
