### PR TITLE
Updated actions/cache@v2 to actions/cache@v4

### DIFF
--- a/.github/actions/gradle-caches/action.yml
+++ b/.github/actions/gradle-caches/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Cache/Restore cached gradle files
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.gradle/caches


### PR DESCRIPTION
To address build issue such as this https://github.com/cowpaths/fullstory-solr/actions/runs/13731730682/job/38409929804?pr=246


>Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: v2`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down