### PR TITLE
no longer persist credentials

### DIFF
--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -29,6 +29,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
     - name: Set up JDK
       uses: actions/setup-java@v3
       with:

--- a/.github/workflows/gradle-precommit.yml
+++ b/.github/workflows/gradle-precommit.yml
@@ -28,6 +28,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
 
     - name: Set up JDK
       uses: actions/setup-java@v3

--- a/.github/workflows/hunspell.yml
+++ b/.github/workflows/hunspell.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
 
     - name: Set up JDK
       uses: actions/setup-java@v3


### PR DESCRIPTION
This PR sets persist-credentials to false to protect against the risk of leaking or persisting github credentials in our workflows
