### PR TITLE
no persist creds

### DIFF
--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -30,6 +30,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
     - name: Set up JDK
       uses: actions/setup-java@v3
       with:

--- a/.github/workflows/gradle-precommit.yml
+++ b/.github/workflows/gradle-precommit.yml
@@ -29,6 +29,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
 
     - name: Set up JDK
       uses: actions/setup-java@v3

--- a/.github/workflows/hunspell.yml
+++ b/.github/workflows/hunspell.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
 
     - name: Set up JDK
       uses: actions/setup-java@v3


### PR DESCRIPTION
This PR sets persist-credentials to false to protect against the risk of leaking or persisting github credentials in our workflows
