### PR TITLE
SAI-6382:  Concurrent merge scheduler that respects a global active thread limit (Lucene)

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
@@ -461,9 +461,15 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
     try {
       sync();
     } finally {
-      if (intraMergeExecutor != null) {
-        intraMergeExecutor.shutdown();
-      }
+      shutdownIntraMergeExecutor();
+    }
+  }
+
+  /** Shuts down and clears the intra-merge executor. Visible to subclasses (e.g. GCMS). */
+  protected synchronized void shutdownIntraMergeExecutor() {
+    if (intraMergeExecutor != null) {
+      intraMergeExecutor.shutdown();
+      intraMergeExecutor = null;
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
@@ -570,9 +570,9 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
         return;
       }
 
-      maybeStall(merge); //check if there's any stalls specific to merge
       boolean success = false;
       try {
+        maybeStall(merge); //check if there's any stalls specific to merge
         // OK to spawn a new merge thread to handle this
         // merge:
         final MergeThread newMergeThread = getMergeThread(mergeSource, merge);

--- a/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
@@ -26,6 +26,8 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
 import org.apache.lucene.index.MergePolicy.OneMerge;
 import org.apache.lucene.internal.tests.TestSecrets;
 import org.apache.lucene.store.AlreadyClosedException;
@@ -585,6 +587,7 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
         return;
       }
 
+      maybeStall(merge);
       boolean success = false;
       try {
         // OK to spawn a new merge thread to handle this
@@ -605,6 +608,7 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
       } finally {
         if (!success) {
           mergeSource.onMergeFinished(merge);
+          postMerge(merge);
         }
       }
     }
@@ -657,6 +661,10 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
     return true;
   }
 
+  protected synchronized void maybeStall(OneMerge merge) {
+    //hook for subclass to stall based on merge
+  }
+
   /** Called from {@link #maybeStall} to pause the calling thread for a bit. */
   protected synchronized void doStall() {
     try {
@@ -684,14 +692,14 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
     return thread;
   }
 
-  synchronized void runOnMergeFinished(MergeSource mergeSource) {
+  synchronized void runOnMergeFinished(MergeThread mergeThread) {
     // the merge call as well as the merge thread handling in the finally
     // block must be sync'd on CMS otherwise stalling decisions might cause
     // us to miss pending merges
     assert mergeThreads.contains(Thread.currentThread()) : "caller is not a merge thread";
     // Let CMS run new merges if necessary:
     try {
-      merge(mergeSource, MergeTrigger.MERGE_FINISHED);
+      merge(mergeThread.mergeSource, MergeTrigger.MERGE_FINISHED);
     } catch (
         @SuppressWarnings("unused")
         AlreadyClosedException ace) {
@@ -712,6 +720,7 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
     final MergeSource mergeSource;
     final OneMerge merge;
     final MergeRateLimiter rateLimiter;
+    Runnable cleanupRunnable;
 
     /** Sole constructor. */
     public MergeThread(MergeSource mergeSource, OneMerge merge) {
@@ -749,7 +758,7 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
                   rateToString(rateLimiter.getMBPerSec())));
         }
 
-        runOnMergeFinished(mergeSource);
+        runOnMergeFinished(this);
 
         if (verbose()) {
           message(String.format(Locale.ROOT, "merge thread %s end", this.getName()));
@@ -762,8 +771,19 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
           // testing.
           handleMergeException(exc);
         }
+      } finally {
+        postMerge(merge);
       }
     }
+  }
+
+  /**
+   * Cleanup after the merge attempt finishes, whether it was successful or not.
+   * <br>
+   * This could be called multiple times hence should be idempotent
+   */
+  protected void postMerge(OneMerge merge) {
+    //hook for subclass to do clean up on mergeThread completion - whether it was successful or not
   }
 
   /** Called when an exception is hit in a background merge thread */

--- a/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
@@ -26,8 +26,6 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
-
 import org.apache.lucene.index.MergePolicy.OneMerge;
 import org.apache.lucene.internal.tests.TestSecrets;
 import org.apache.lucene.store.AlreadyClosedException;
@@ -380,9 +378,6 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
         newMBPerSec = targetMBPerSec;
       }
 
-      // Subclasses (e.g. GlobalConcurrentMergeScheduler) may further restrict the rate.
-      newMBPerSec = adjustMergeRate(mergeThread, newMBPerSec);
-
       MergeRateLimiter rateLimiter = mergeThread.rateLimiter;
       double curMBPerSec = rateLimiter.getMBPerSec();
 
@@ -435,18 +430,6 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
     if (verbose()) {
       message(message.toString());
     }
-  }
-
-  /**
-   * Hook for subclasses to further restrict (or leave unchanged) the merge IO rate chosen by {@link
-   * #updateMergeThreads()}. Returning {@code 0.0} pauses the merge thread.
-   *
-   * @param mergeThread the merge thread whose rate is being set
-   * @param proposedMBPerSec rate that this scheduler would apply before external constraints
-   * @return the rate to apply (may be {@code 0.0} to pause)
-   */
-  protected double adjustMergeRate(MergeThread mergeThread, double proposedMBPerSec) {
-    return proposedMBPerSec;
   }
 
   private synchronized void initDynamicDefaults(Directory directory) throws IOException {
@@ -587,7 +570,7 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
         return;
       }
 
-      maybeStall(merge);
+      maybeStall(merge); //check if there's any stalls specific to merge
       boolean success = false;
       try {
         // OK to spawn a new merge thread to handle this
@@ -720,7 +703,6 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
     final MergeSource mergeSource;
     final OneMerge merge;
     final MergeRateLimiter rateLimiter;
-    Runnable cleanupRunnable;
 
     /** Sole constructor. */
     public MergeThread(MergeSource mergeSource, OneMerge merge) {

--- a/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
@@ -378,6 +378,9 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
         newMBPerSec = targetMBPerSec;
       }
 
+      // Subclasses (e.g. GlobalConcurrentMergeScheduler) may further restrict the rate.
+      newMBPerSec = adjustMergeRate(mergeThread, newMBPerSec);
+
       MergeRateLimiter rateLimiter = mergeThread.rateLimiter;
       double curMBPerSec = rateLimiter.getMBPerSec();
 
@@ -432,6 +435,18 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
     }
   }
 
+  /**
+   * Hook for subclasses to further restrict (or leave unchanged) the merge IO rate chosen by {@link
+   * #updateMergeThreads()}. Returning {@code 0.0} pauses the merge thread.
+   *
+   * @param mergeThread the merge thread whose rate is being set
+   * @param proposedMBPerSec rate that this scheduler would apply before external constraints
+   * @return the rate to apply (may be {@code 0.0} to pause)
+   */
+  protected double adjustMergeRate(MergeThread mergeThread, double proposedMBPerSec) {
+    return proposedMBPerSec;
+  }
+
   private synchronized void initDynamicDefaults(Directory directory) throws IOException {
     if (maxThreadCount == AUTO_DETECT_MERGES_AND_THREADS) {
       setDefaultMaxMergesAndThreads(false);
@@ -461,15 +476,9 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
     try {
       sync();
     } finally {
-      shutdownIntraMergeExecutor();
-    }
-  }
-
-  /** Shuts down and clears the intra-merge executor. Visible to subclasses (e.g. GCMS). */
-  protected synchronized void shutdownIntraMergeExecutor() {
-    if (intraMergeExecutor != null) {
-      intraMergeExecutor.shutdown();
-      intraMergeExecutor = null;
+      if (intraMergeExecutor != null) {
+        intraMergeExecutor.shutdown();
+      }
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
@@ -572,7 +572,9 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
 
       boolean success = false;
       try {
-        maybeStall(merge); //check if there's any stalls specific to merge
+        if (maybeStall(merge) == false) {
+          return;
+        }
         // OK to spawn a new merge thread to handle this
         // merge:
         final MergeThread newMergeThread = getMergeThread(mergeSource, merge);
@@ -644,8 +646,13 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
     return true;
   }
 
-  protected synchronized void maybeStall(OneMerge merge) {
-    //hook for subclass to stall based on merge
+  /**
+   * Hook for subclasses to stall before spawning a merge thread. Return {@code false} if the merge
+   * should not be started (e.g. aborted, or caller is a merge thread that must not block). The
+   * caller will invoke {@link MergeSource#onMergeFinished} and {@link #postMerge}.
+   */
+  protected synchronized boolean maybeStall(OneMerge merge) {
+    return true;
   }
 
   /** Called from {@link #maybeStall} to pause the calling thread for a bit. */

--- a/lucene/core/src/java/org/apache/lucene/index/GlobalConcurrentMergeScheduler.java
+++ b/lucene/core/src/java/org/apache/lucene/index/GlobalConcurrentMergeScheduler.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.index;
+
+import java.io.IOException;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.InfoStream;
+
+/**
+ * A JVM-wide singleton {@link ConcurrentMergeScheduler}. All {@link IndexWriter}s that use this
+ * scheduler share one merge-thread pool, so {@code maxThreadCount} / {@code maxMergeCount} cap
+ * concurrent merges across the entire process rather than per core.
+ *
+ * <p>Obtain the shared instance via {@link #getInstance()}. {@link IndexWriter} lifecycle is
+ * refcounted: {@link #initialize} increments the active-writer count and {@link #close} decrements
+ * it. Only the last writer's {@code close} tears down the pool; earlier closes are no-ops so other
+ * cores can keep merging.
+ *
+ * <p>When one writer closes while others remain, {@link MergeTrigger#CLOSING} does not disable
+ * global IO throttle (which would otherwise affect remaining writers).
+ *
+ * @lucene.experimental
+ */
+public final class GlobalConcurrentMergeScheduler extends ConcurrentMergeScheduler {
+
+  private static final Object INSTANCE_LOCK = new Object();
+  private static GlobalConcurrentMergeScheduler INSTANCE;
+
+  /** Number of IndexWriters currently holding this scheduler open. */
+  private int activeWriters;
+
+  private GlobalConcurrentMergeScheduler() {}
+
+  /** Returns the JVM-wide singleton instance, creating it on first use. */
+  public static GlobalConcurrentMergeScheduler getInstance() {
+    synchronized (INSTANCE_LOCK) {
+      if (INSTANCE == null) {
+        INSTANCE = new GlobalConcurrentMergeScheduler();
+      }
+      return INSTANCE;
+    }
+  }
+
+  /**
+   * Resets the singleton for tests. Must only be called when no writers still hold the scheduler
+   * open ({@link #getActiveWriterCount()} == 0).
+   *
+   * @lucene.internal
+   */
+  public static void resetForTesting() {
+    synchronized (INSTANCE_LOCK) {
+      if (INSTANCE != null) {
+        synchronized (INSTANCE) {
+          if (INSTANCE.activeWriters != 0) {
+            throw new IllegalStateException(
+                "Cannot reset GlobalConcurrentMergeScheduler while activeWriters="
+                    + INSTANCE.activeWriters);
+          }
+        }
+      }
+      INSTANCE = null;
+    }
+  }
+
+  /** Returns how many IndexWriters currently reference this scheduler. */
+  public synchronized int getActiveWriterCount() {
+    return activeWriters;
+  }
+
+  @Override
+  void initialize(InfoStream infoStream, Directory directory) throws IOException {
+    synchronized (this) {
+      activeWriters++;
+      if (activeWriters == 1 || intraMergeExecutor == null) {
+        // First writer, or re-open after a full close tore down the executor.
+        super.initialize(infoStream, directory);
+      } else {
+        // Keep sharing the existing pool; refresh infoStream for logging (last-wins).
+        this.infoStream = infoStream;
+      }
+    }
+  }
+
+  @Override
+  public synchronized void merge(MergeSource mergeSource, MergeTrigger trigger) throws IOException {
+    // CMS disables IO throttle on CLOSING; that must stay local to the last writer so other
+    // cores are not affected when one core unloads.
+    if (trigger == MergeTrigger.CLOSING && activeWriters > 1) {
+      super.merge(mergeSource, MergeTrigger.EXPLICIT);
+      return;
+    }
+    super.merge(mergeSource, trigger);
+  }
+
+  @Override
+  public void close() throws IOException {
+    final boolean doFullClose;
+    synchronized (this) {
+      if (activeWriters <= 0) {
+        return;
+      }
+      activeWriters--;
+      doFullClose = activeWriters == 0;
+    }
+    if (doFullClose) {
+      // Join remaining merge threads and shut down the CachedExecutor only.
+      // Do not call MergeScheduler.close(): its SameThreadExecutorService is final and cannot
+      // be recreated, but cores may come and go over the JVM lifetime.
+      // Do not hold 'this' across sync() — merge threads need the CMS monitor.
+      try {
+        sync();
+      } finally {
+        shutdownIntraMergeExecutor();
+      }
+    }
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getSimpleName()
+        + "[singleton, activeWriters="
+        + getActiveWriterCount()
+        + ", "
+        + "maxThreadCount="
+        + getMaxThreadCount()
+        + ", "
+        + "maxMergeCount="
+        + getMaxMergeCount()
+        + ", "
+        + "ioThrottle="
+        + getAutoIOThrottle()
+        + "]";
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/index/GlobalConcurrentMergeScheduler.java
+++ b/lucene/core/src/java/org/apache/lucene/index/GlobalConcurrentMergeScheduler.java
@@ -43,7 +43,7 @@ public class GlobalConcurrentMergeScheduler extends ConcurrentMergeScheduler {
 
     /**
      * Release a previously acquired permit for the given merge.
-     * This is idempotent: if the merge was already released, this method is a no-op.
+     * This is idempotent: if the merge was already released/never acquired, this method is a no-op.
      * @param merge
      */
     void release(MergePolicy.OneMerge merge);

--- a/lucene/core/src/java/org/apache/lucene/index/GlobalConcurrentMergeScheduler.java
+++ b/lucene/core/src/java/org/apache/lucene/index/GlobalConcurrentMergeScheduler.java
@@ -16,128 +16,72 @@
  */
 package org.apache.lucene.index;
 
-import java.io.IOException;
 import java.util.Objects;
-import org.apache.lucene.store.Directory;
-import org.apache.lucene.util.InfoStream;
 
 /**
- * Per-{@link IndexWriter} {@link ConcurrentMergeScheduler} that consults a shared {@link
- * MergeConcurrencyGate} when assigning merge IO rates. The gate may force a merge thread to pause
- * ({@code 0.0} MB/s) so that node-wide running-merge concurrency can be capped without sharing one
- * CMS instance across cores.
- *
- * <p>Local {@code maxThreadCount}/{@code maxMergeCount}, IO throttle, stall, and close behavior
- * remain per-scheduler. The gate only adds an extra pause constraint on top.
+ * Per-{@link IndexWriter} {@link ConcurrentMergeScheduler} that stalls merge spawning against a
+ * shared {@link MergeConcurrencySemaphore}, so node-wide concurrent merge threads can be capped
+ * without sharing one CMS instance across cores.
  *
  * @lucene.experimental
  */
-public final class GlobalConcurrentMergeScheduler extends ConcurrentMergeScheduler {
+public class GlobalConcurrentMergeScheduler extends ConcurrentMergeScheduler {
 
   /**
-   * Shared concurrency gate used by {@link GlobalConcurrentMergeScheduler} instances. Implemented
-   * outside Lucene (e.g. Solr) so clusterprops / ZK wiring stays out of this class.
+   * Shared concurrency semaphore used by {@link GlobalConcurrentMergeScheduler} instances.
+   * Implemented outside Lucene (e.g. Solr) so clusterprops / ZK wiring stays out of this class.
    */
-  public interface MergeConcurrencyGate {
-    /**
-     * Possibly reduce {@code proposedMBPerSec} (typically to {@code 0.0} to pause) based on
-     * node-wide running-merge limits.
-     *
-     * @param scheduler the scheduler owning {@code mergeKey}
-     * @param mergeKey stable identity for the merge thread (typically the {@link MergeThread})
-     * @param proposedMBPerSec rate the local CMS would apply
-     * @return rate to apply
-     */
-    double adjustRate(
-        ConcurrentMergeScheduler scheduler, Object mergeKey, double proposedMBPerSec);
+  public interface MergeConcurrencySemaphore {
+    boolean tryAcquire(MergePolicy.OneMerge merge);
 
-    /** Called when a scheduler is bound to an {@link IndexWriter}. */
-    void register(ConcurrentMergeScheduler scheduler);
-
-    /** Called when a scheduler is closed; must release that scheduler's permits. */
-    void unregister(ConcurrentMergeScheduler scheduler);
-
-    /**
-     * Called after this scheduler finished {@link #updateMergeThreads()}. Implementations must not
-     * call other schedulers synchronously (deadlock risk); wake peers asynchronously.
-     */
-    void afterUpdate(ConcurrentMergeScheduler scheduler);
+    void release(MergePolicy.OneMerge merge);
   }
 
-  /** Gate that never restricts rates (useful in unit tests). */
-  public static final MergeConcurrencyGate NOOP_GATE =
-      new MergeConcurrencyGate() {
+  /** Semaphore that never restricts merge spawning (useful in unit tests). */
+  public static final MergeConcurrencySemaphore UNLIMITED =
+      new MergeConcurrencySemaphore() {
         @Override
-        public double adjustRate(
-            ConcurrentMergeScheduler scheduler, Object mergeKey, double proposedMBPerSec) {
-          return proposedMBPerSec;
+        public boolean tryAcquire(MergePolicy.OneMerge merge) {
+          return true;
         }
 
         @Override
-        public void register(ConcurrentMergeScheduler scheduler) {}
-
-        @Override
-        public void unregister(ConcurrentMergeScheduler scheduler) {}
-
-        @Override
-        public void afterUpdate(ConcurrentMergeScheduler scheduler) {}
+        public void release(MergePolicy.OneMerge merge) {}
       };
 
-  private final MergeConcurrencyGate gate;
+  private final MergeConcurrencySemaphore semaphore;
 
-  /** Creates a per-writer scheduler that consults {@code gate} for node-wide pause decisions. */
-  public GlobalConcurrentMergeScheduler(MergeConcurrencyGate gate) {
-    this.gate = Objects.requireNonNull(gate, "gate");
+  public GlobalConcurrentMergeScheduler(MergeConcurrencySemaphore semaphore) {
+    this.semaphore = Objects.requireNonNull(semaphore);
   }
 
-  /** Returns the gate injected at construction. */
-  public MergeConcurrencyGate getGate() {
-    return gate;
-  }
-
-  /**
-   * Re-evaluates pause/run rates. Invoked asynchronously by the gate when peer schedulers free
-   * permits; must not be called while holding another CMS lock.
-   */
-  public void rebalanceMergeThreads() {
-    updateMergeThreads();
+  /** Returns the semaphore injected at construction. */
+  public MergeConcurrencySemaphore getSemaphore() {
+    return semaphore;
   }
 
   @Override
-  protected double adjustMergeRate(MergeThread mergeThread, double proposedMBPerSec) {
-    return gate.adjustRate(this, mergeThread, proposedMBPerSec);
-  }
+  protected synchronized void maybeStall(MergePolicy.OneMerge merge) {
+    super.maybeStall(merge);
 
-  @Override
-  protected synchronized void updateMergeThreads() {
-    super.updateMergeThreads();
-    gate.afterUpdate(this);
-  }
-
-  @Override
-  void initialize(InfoStream infoStream, Directory directory) throws IOException {
-    super.initialize(infoStream, directory);
-    gate.register(this);
-  }
-
-  @Override
-  public void close() throws IOException {
-    try {
-      gate.unregister(this);
-    } finally {
-      super.close();
+    while (!semaphore.tryAcquire(merge)) {
+      if (verbose()) {
+        message("    too many merges globally; stalling...");
+      }
+      doStall();
     }
   }
 
   @Override
-  public String toString() {
-    return getClass().getSimpleName()
-        + "[maxThreadCount="
-        + getMaxThreadCount()
-        + ", maxMergeCount="
-        + getMaxMergeCount()
-        + ", ioThrottle="
-        + getAutoIOThrottle()
-        + "]";
+  synchronized void runOnMergeFinished(MergeThread mergeThread) {
+    semaphore.release(mergeThread.merge); //need to release the semaphore here as super might call merge(mergeThread.mergeSource, MergeTrigger.MERGE_FINISHED), which could deadlock if we don't release the semaphore
+    super.runOnMergeFinished(mergeThread);
   }
+
+  @Override
+  protected void postMerge(MergePolicy.OneMerge merge) {
+    semaphore.release(merge); //in case the merge failed we still need to release the semaphore. If it was already released it will just be a no-op
+  }
+
+
 }

--- a/lucene/core/src/java/org/apache/lucene/index/GlobalConcurrentMergeScheduler.java
+++ b/lucene/core/src/java/org/apache/lucene/index/GlobalConcurrentMergeScheduler.java
@@ -32,8 +32,20 @@ public class GlobalConcurrentMergeScheduler extends ConcurrentMergeScheduler {
    * Implemented outside Lucene (e.g. Solr) so clusterprops / ZK wiring stays out of this class.
    */
   public interface MergeConcurrencySemaphore {
+    /**
+     * Tries to acquire a permit for the given merge. Returns true if a permit was acquired, false otherwise.
+     * <b>
+     * Call on merge that holds an active is a no-op and will return true
+     * @param merge
+     * @return whether a permit is successfully acquired by this merge
+     */
     boolean tryAcquire(MergePolicy.OneMerge merge);
 
+    /**
+     * Release a previously acquired permit for the given merge.
+     * This is idempotent: if the merge was already released, this method is a no-op.
+     * @param merge
+     */
     void release(MergePolicy.OneMerge merge);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/GlobalConcurrentMergeScheduler.java
+++ b/lucene/core/src/java/org/apache/lucene/index/GlobalConcurrentMergeScheduler.java
@@ -17,131 +17,126 @@
 package org.apache.lucene.index;
 
 import java.io.IOException;
+import java.util.Objects;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.InfoStream;
 
 /**
- * A JVM-wide singleton {@link ConcurrentMergeScheduler}. All {@link IndexWriter}s that use this
- * scheduler share one merge-thread pool, so {@code maxThreadCount} / {@code maxMergeCount} cap
- * concurrent merges across the entire process rather than per core.
+ * Per-{@link IndexWriter} {@link ConcurrentMergeScheduler} that consults a shared {@link
+ * MergeConcurrencyGate} when assigning merge IO rates. The gate may force a merge thread to pause
+ * ({@code 0.0} MB/s) so that node-wide running-merge concurrency can be capped without sharing one
+ * CMS instance across cores.
  *
- * <p>Obtain the shared instance via {@link #getInstance()}. {@link IndexWriter} lifecycle is
- * refcounted: {@link #initialize} increments the active-writer count and {@link #close} decrements
- * it. Only the last writer's {@code close} tears down the pool; earlier closes are no-ops so other
- * cores can keep merging.
- *
- * <p>When one writer closes while others remain, {@link MergeTrigger#CLOSING} does not disable
- * global IO throttle (which would otherwise affect remaining writers).
+ * <p>Local {@code maxThreadCount}/{@code maxMergeCount}, IO throttle, stall, and close behavior
+ * remain per-scheduler. The gate only adds an extra pause constraint on top.
  *
  * @lucene.experimental
  */
 public final class GlobalConcurrentMergeScheduler extends ConcurrentMergeScheduler {
 
-  private static final Object INSTANCE_LOCK = new Object();
-  private static GlobalConcurrentMergeScheduler INSTANCE;
+  /**
+   * Shared concurrency gate used by {@link GlobalConcurrentMergeScheduler} instances. Implemented
+   * outside Lucene (e.g. Solr) so clusterprops / ZK wiring stays out of this class.
+   */
+  public interface MergeConcurrencyGate {
+    /**
+     * Possibly reduce {@code proposedMBPerSec} (typically to {@code 0.0} to pause) based on
+     * node-wide running-merge limits.
+     *
+     * @param scheduler the scheduler owning {@code mergeKey}
+     * @param mergeKey stable identity for the merge thread (typically the {@link MergeThread})
+     * @param proposedMBPerSec rate the local CMS would apply
+     * @return rate to apply
+     */
+    double adjustRate(
+        ConcurrentMergeScheduler scheduler, Object mergeKey, double proposedMBPerSec);
 
-  /** Number of IndexWriters currently holding this scheduler open. */
-  private int activeWriters;
+    /** Called when a scheduler is bound to an {@link IndexWriter}. */
+    void register(ConcurrentMergeScheduler scheduler);
 
-  private GlobalConcurrentMergeScheduler() {}
+    /** Called when a scheduler is closed; must release that scheduler's permits. */
+    void unregister(ConcurrentMergeScheduler scheduler);
 
-  /** Returns the JVM-wide singleton instance, creating it on first use. */
-  public static GlobalConcurrentMergeScheduler getInstance() {
-    synchronized (INSTANCE_LOCK) {
-      if (INSTANCE == null) {
-        INSTANCE = new GlobalConcurrentMergeScheduler();
-      }
-      return INSTANCE;
-    }
+    /**
+     * Called after this scheduler finished {@link #updateMergeThreads()}. Implementations must not
+     * call other schedulers synchronously (deadlock risk); wake peers asynchronously.
+     */
+    void afterUpdate(ConcurrentMergeScheduler scheduler);
+  }
+
+  /** Gate that never restricts rates (useful in unit tests). */
+  public static final MergeConcurrencyGate NOOP_GATE =
+      new MergeConcurrencyGate() {
+        @Override
+        public double adjustRate(
+            ConcurrentMergeScheduler scheduler, Object mergeKey, double proposedMBPerSec) {
+          return proposedMBPerSec;
+        }
+
+        @Override
+        public void register(ConcurrentMergeScheduler scheduler) {}
+
+        @Override
+        public void unregister(ConcurrentMergeScheduler scheduler) {}
+
+        @Override
+        public void afterUpdate(ConcurrentMergeScheduler scheduler) {}
+      };
+
+  private final MergeConcurrencyGate gate;
+
+  /** Creates a per-writer scheduler that consults {@code gate} for node-wide pause decisions. */
+  public GlobalConcurrentMergeScheduler(MergeConcurrencyGate gate) {
+    this.gate = Objects.requireNonNull(gate, "gate");
+  }
+
+  /** Returns the gate injected at construction. */
+  public MergeConcurrencyGate getGate() {
+    return gate;
   }
 
   /**
-   * Resets the singleton for tests. Must only be called when no writers still hold the scheduler
-   * open ({@link #getActiveWriterCount()} == 0).
-   *
-   * @lucene.internal
+   * Re-evaluates pause/run rates. Invoked asynchronously by the gate when peer schedulers free
+   * permits; must not be called while holding another CMS lock.
    */
-  public static void resetForTesting() {
-    synchronized (INSTANCE_LOCK) {
-      if (INSTANCE != null) {
-        synchronized (INSTANCE) {
-          if (INSTANCE.activeWriters != 0) {
-            throw new IllegalStateException(
-                "Cannot reset GlobalConcurrentMergeScheduler while activeWriters="
-                    + INSTANCE.activeWriters);
-          }
-        }
-      }
-      INSTANCE = null;
-    }
+  public void rebalanceMergeThreads() {
+    updateMergeThreads();
   }
 
-  /** Returns how many IndexWriters currently reference this scheduler. */
-  public synchronized int getActiveWriterCount() {
-    return activeWriters;
+  @Override
+  protected double adjustMergeRate(MergeThread mergeThread, double proposedMBPerSec) {
+    return gate.adjustRate(this, mergeThread, proposedMBPerSec);
+  }
+
+  @Override
+  protected synchronized void updateMergeThreads() {
+    super.updateMergeThreads();
+    gate.afterUpdate(this);
   }
 
   @Override
   void initialize(InfoStream infoStream, Directory directory) throws IOException {
-    synchronized (this) {
-      activeWriters++;
-      if (activeWriters == 1 || intraMergeExecutor == null) {
-        // First writer, or re-open after a full close tore down the executor.
-        super.initialize(infoStream, directory);
-      } else {
-        // Keep sharing the existing pool; refresh infoStream for logging (last-wins).
-        this.infoStream = infoStream;
-      }
-    }
-  }
-
-  @Override
-  public synchronized void merge(MergeSource mergeSource, MergeTrigger trigger) throws IOException {
-    // CMS disables IO throttle on CLOSING; that must stay local to the last writer so other
-    // cores are not affected when one core unloads.
-    if (trigger == MergeTrigger.CLOSING && activeWriters > 1) {
-      super.merge(mergeSource, MergeTrigger.EXPLICIT);
-      return;
-    }
-    super.merge(mergeSource, trigger);
+    super.initialize(infoStream, directory);
+    gate.register(this);
   }
 
   @Override
   public void close() throws IOException {
-    final boolean doFullClose;
-    synchronized (this) {
-      if (activeWriters <= 0) {
-        return;
-      }
-      activeWriters--;
-      doFullClose = activeWriters == 0;
-    }
-    if (doFullClose) {
-      // Join remaining merge threads and shut down the CachedExecutor only.
-      // Do not call MergeScheduler.close(): its SameThreadExecutorService is final and cannot
-      // be recreated, but cores may come and go over the JVM lifetime.
-      // Do not hold 'this' across sync() — merge threads need the CMS monitor.
-      try {
-        sync();
-      } finally {
-        shutdownIntraMergeExecutor();
-      }
+    try {
+      gate.unregister(this);
+    } finally {
+      super.close();
     }
   }
 
   @Override
   public String toString() {
     return getClass().getSimpleName()
-        + "[singleton, activeWriters="
-        + getActiveWriterCount()
-        + ", "
-        + "maxThreadCount="
+        + "[maxThreadCount="
         + getMaxThreadCount()
-        + ", "
-        + "maxMergeCount="
+        + ", maxMergeCount="
         + getMaxMergeCount()
-        + ", "
-        + "ioThrottle="
+        + ", ioThrottle="
         + getAutoIOThrottle()
         + "]";
   }

--- a/lucene/core/src/java/org/apache/lucene/index/GlobalConcurrentMergeScheduler.java
+++ b/lucene/core/src/java/org/apache/lucene/index/GlobalConcurrentMergeScheduler.java
@@ -61,15 +61,31 @@ public class GlobalConcurrentMergeScheduler extends ConcurrentMergeScheduler {
   }
 
   @Override
-  protected synchronized void maybeStall(MergePolicy.OneMerge merge) {
-    super.maybeStall(merge);
+  protected synchronized boolean maybeStall(MergePolicy.OneMerge merge) {
+    if (merge.isAborted()) {
+      return false;
+    }
+
+    if (super.maybeStall(merge) == false) {
+      return false;
+    }
+
+    // Never stall a merge thread (see maybeStall(MergeSource)): if no global permit is
+    // available, skip spawning so this thread can finish and notify waiters.
+    if (mergeThreads.contains(Thread.currentThread())) {
+      return semaphore.tryAcquire(merge);
+    }
 
     while (!semaphore.tryAcquire(merge)) {
+      if (merge.isAborted()) {
+        return false;
+      }
       if (verbose()) {
         message("    too many merges globally; stalling...");
       }
       doStall();
     }
+    return true;
   }
 
   @Override


### PR DESCRIPTION
## Description
TL;DR : right after switching to `TemporalMergePolicy`, extra merges might temporarily spike storage usage quite significantly, causing distress with node tight on resource.

Details in https://fullstory.atlassian.net/browse/SAI-6382 

This PR enforces a global concurrent merge limit (instead of per core) 

## Solution
In Lucene level, introducing a new `GlobalConcurrentMergeScheduler` (extends `ConcurrentMergeScheduler`), which accepts a "semaphore" (provided by Solr changes) which limit concurrent merge thread globally

Changes to existing `ConcurrentMergeScheduler`:
1. Added a new maybeStall(OneMerge) method, so the subclass can hold off the creation of `MergeThread` if there are already too many ongoing ones. This works similarly to `maybeStall(MergeSource)`, we cannot simply override the `maybeStall(MergeSource)` due to execution order (minimize changes)
2. Added a cleanup method `afterMerge` which allow child class to release semaphore 


## Remarks
There are 2 rate control mechanism in `ConcurrentMergeScheduler`:
1. maybeStall - check before spawning the merge thread (current implementation)
2. updateMergeThread - pause/unpause active threads based on some criteria (small merges first etc)

Originally I attempted to override the `updateMergeThreads` instead. by using 0.0 to "pause" threads based on semaphore, but it turns out to be extremely challenging as the logic is quite tightly coupled together and it's hard to override some piece w/o issue on others, and it's also hard to "unpause" threads cross core (no blocking right now) 

Therefore I eventually went for the current approach which stalling is a bit cleaner. 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core merge scheduling and synchronization paths in `ConcurrentMergeScheduler`; incorrect semaphore release/acquire ordering could cause deadlocks or leaked permits under load.
> 
> **Overview**
> Adds **node-wide** merge concurrency control while keeping one `ConcurrentMergeScheduler` (or subclass) per `IndexWriter` core.
> 
> **`ConcurrentMergeScheduler`** now calls a new **`maybeStall(OneMerge)`** hook immediately before starting a `MergeThread`. Returning `false` skips thread spawn; the failure path runs **`onMergeFinished`** and a new **`postMerge(OneMerge)`** cleanup hook (intended to be idempotent). **`runOnMergeFinished`** now receives the **`MergeThread`** instead of `MergeSource`, and **`postMerge`** is also invoked when a merge thread finishes (success or failure).
> 
> **`GlobalConcurrentMergeScheduler`** (experimental) plugs in a shared **`MergeConcurrencySemaphore`** (implemented outside Lucene, e.g. Solr). Indexing threads **stall** until a global permit is available; threads already running merges **do not block**—they only `tryAcquire` so they can finish and wake waiters. Permits are **released** in **`runOnMergeFinished`** (before chaining to super, to avoid deadlock) and again in **`postMerge`** for failed or aborted merges. **`UNLIMITED`** is provided for tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 883c231813cdeae3a247d491ae8ffb07b8431edb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->